### PR TITLE
#7 repositoryクラス作成

### DIFF
--- a/lib/model/api_result.dart
+++ b/lib/model/api_result.dart
@@ -1,0 +1,8 @@
+class ApiResult<T> {
+  final RequestResult result;
+  final T data;
+
+  ApiResult({required this.result, required this.data});
+}
+
+enum RequestResult { success, apiError }

--- a/lib/model/repo_search_input.dart
+++ b/lib/model/repo_search_input.dart
@@ -1,0 +1,6 @@
+class RepoSearchInput {
+  final String searchText;
+  final String sort;
+
+  RepoSearchInput({required this.searchText, required this.sort});
+}

--- a/lib/repository/github_repository.dart
+++ b/lib/repository/github_repository.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:yumemi_flutter_codecheck/model/api_result.dart';
+import 'package:yumemi_flutter_codecheck/model/repository_info.dart';
+
+class GithubSearchRepository {
+  GithubSearchRepository({http.Client? client}) {
+    _client = client ?? http.Client();
+  }
+
+  late http.Client _client;
+
+  // 検索文字列を渡して、github上のrepositoryを検索する
+  Future<ApiResult<RepoInfo>> getRepoInfo({
+    required String searchText,
+    required String sort,
+    int page = 1,
+  }) async {
+    try {
+      //
+      final resUrl =
+          'https://api.github.com/search/repositories?q=$searchText&sort=$sort&page=$page&per_page=20';
+
+      final apiUrl = Uri.parse(Uri.encodeFull(resUrl));
+      http.Response response = await _client
+          .get(apiUrl)
+          .timeout(const Duration(seconds: 30));
+
+      final jsonData = json.decode(response.body);
+      final parsedData = RepoInfo.fromJson(jsonData);
+      return ApiResult(
+        result: RequestResult.success,
+        data: parsedData,
+      );
+    } catch (e) {
+      return ApiResult(
+        result: RequestResult.apiError,
+        data: RepoInfo(totalCount: 0, items: []),
+      );
+    }
+  }
+}


### PR DESCRIPTION
## 概要
Github/search_repositoriesライブラリ用のrepositoryクラス作成

## 対応内容
closes #7 

- Github/search_repositoriesライブラリ用のrepositoryクラス作成
- 実行結果が成功か失敗か、呼び出し元に返せるよう実装

## スクリーンショット等

## 備考
