### PR TITLE
ライセンス表示機能の実装

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,5 +4,7 @@
   "github_repository_search_comment": "----------repository検索画面----------",
   "repositorySearchScreenTitle": "Search Repositories",
   "searchTextFieldHintText": "repository name",
-  "searchNoneResultMessage": "No results found."
+  "searchNoneResultMessage": "No results found.",
+  "searchShowLicense": "Show License"
+
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -4,5 +4,7 @@
   "github_repository_search_comment": "----------repository検索画面----------",
   "repositorySearchScreenTitle": "レポジトリ検索",
   "searchTextFieldHintText": "レポジトリ名",
-  "searchNoneResultMessage": "検索結果が0件です。"
+  "searchNoneResultMessage": "検索結果が0件です。",
+  "searchShowLicense": "ライセンス表示"
+
 }

--- a/lib/molecules/popup_setting_button.dart
+++ b/lib/molecules/popup_setting_button.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_codecheck/l10n/l10n.dart';
+
+/// 検索画面の設定ボタン
+///
+/// タップ時、タップ可能な選択肢を表示する
+class SearchSettingButton extends StatelessWidget {
+  const SearchSettingButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      icon: Icon(Icons.settings),
+      onSelected: (String value) {
+        switch (value) {
+          case 'showLicense':
+            // ライセンス画面に遷移
+            showLicensePage(context: context);
+            break;
+        }
+      },
+      itemBuilder:
+          (BuildContext context) => [
+            PopupMenuItem(
+              value: 'showLicense',
+              child: Text(L10n.of(context)!.searchShowLicense),
+            ),
+          ],
+    );
+  }
+}

--- a/lib/view/github_search_screen.dart
+++ b/lib/view/github_search_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter_codecheck/l10n/l10n.dart';
 import 'package:yumemi_flutter_codecheck/model/repo_search_input.dart';
+import 'package:yumemi_flutter_codecheck/molecules/popup_setting_button.dart';
 import 'package:yumemi_flutter_codecheck/molecules/repository_list_tile.dart';
 
 import '../molecules/search_input_bar.dart';
@@ -36,6 +37,9 @@ class GithubSearchScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text(L10n.of(context)!.repositorySearchScreenTitle),
         actions: [
+          // 設定ボタン
+          SearchSettingButton(),
+          // テーマ切り替えボタン
           IconButton(
             // todo: ダークモード対応
             icon: Icon(Icons.dark_mode),


### PR DESCRIPTION
## 概要
## 対応内容
closes #12 

* ライセンス表示ができる設定ボタンを実装

## スクリーンショット等
| 検索画面 | 設定ボタンタップ時 |ライセンスページ |
| ---- | ---- | ----|
|  <img width="337" alt="スクリーンショット 2025-02-25 2 39 16" src="https://github.com/user-attachments/assets/48453022-cbac-4140-82f2-9905d16d8a0d" />|  <img width="314" alt="スクリーンショット 2025-02-25 2 39 11" src="https://github.com/user-attachments/assets/756e2c5e-d592-409e-a8b1-7ae8ce029cf6" /> |  <img width="336" alt="スクリーンショット 2025-02-25 2 39 21" src="https://github.com/user-attachments/assets/82c6a02e-1f55-440f-8898-92a4dc3b789b" /> |


## 備考
