### PR TITLE
#21 エラー表示

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,6 +5,7 @@
   "repositorySearchScreenTitle": "Search Repositories",
   "searchTextFieldHintText": "repository name",
   "searchNoneResultMessage": "No results found.",
-  "searchShowLicense": "Show License"
+  "searchShowLicense": "Show License",
+  "searchApiError": "An error occurred."
 
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -5,6 +5,7 @@
   "repositorySearchScreenTitle": "レポジトリ検索",
   "searchTextFieldHintText": "レポジトリ名",
   "searchNoneResultMessage": "検索結果が0件です。",
-  "searchShowLicense": "ライセンス表示"
+  "searchShowLicense": "ライセンス表示",
+  "searchApiError": "通信エラーが発生しました。"
 
 }

--- a/lib/view/github_search_screen.dart
+++ b/lib/view/github_search_screen.dart
@@ -69,7 +69,7 @@ class GithubSearchScreen extends ConsumerWidget {
                 return RepositoryListTile(items: data.items);
               },
               // todo: エラー時の表示実装
-              error: (error, stack) => SizedBox.shrink(),
+              error: (error, stack) => Text(L10n.of(context)!.searchApiError),
               loading: () => CircularProgressIndicator(),
             ),
           ],


### PR DESCRIPTION
## 対応内容
closes #21

* search/repositoriesとの通信エラーが発生した場合、エラー文言を表示

## スクリーンショット等
<img width="336" alt="スクリーンショット 2025-02-25 17 43 43" src="https://github.com/user-attachments/assets/e8102afc-0f79-45b2-b9bf-24402bc6d3d2" />


## 備考
